### PR TITLE
Feature Update: Enable user defined HOMEBREW_PREFIX in Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,12 +176,12 @@ else
 
   if [[ -z "${HOMEBREW_PREFIX}" ]]
   then
-      echo "HOMEBREW_PREFIX is not set. Installing to ${HOMEBREW_PREFIX}"
+    echo "HOMEBREW_PREFIX is not set. Installing to ${HOMEBREW_PREFIX}"
   else
-      echo "HOMEBREW_PREFIX is set to: ${HOMEBREW_PREFIX}"
-      echo "Installing to ${HOMEBREW_PREFIX}"
+    echo "HOMEBREW_PREFIX is set to: ${HOMEBREW_PREFIX}"
+    echo "Installing to ${HOMEBREW_PREFIX}"
   fi
-  
+
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
 

--- a/install.sh
+++ b/install.sh
@@ -170,8 +170,17 @@ then
 else
   UNAME_MACHINE="$(uname -m)"
 
-  # On Linux, this script installs to /home/linuxbrew/.linuxbrew only
+  # On Linux, this script installs to /home/linuxbrew/.linuxbrew only if HOMEBREW_PREFIX is not set.
+
   HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+
+  if [ -z "$HOMEBREW_PREFIX" ]; then
+      echo "HOMEBREW_PREFIX is not set. Installing to $HOMEBREW_PREFIX"
+  else
+      echo "HOMEBREW_PREFIX is set to: $HOMEBREW_PREFIX"
+      echo "Installing to $HOMEBREW_PREFIX"
+  fi
+  
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
 

--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,8 @@ else
 
   HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
 
-  if [[ -z "$HOMEBREW_PREFIX" ]]; then
+  if [[ -z "${HOMEBREW_PREFIX}" ]]
+  then
       echo "HOMEBREW_PREFIX is not set. Installing to ${HOMEBREW_PREFIX}"
   else
       echo "HOMEBREW_PREFIX is set to: ${HOMEBREW_PREFIX}"

--- a/install.sh
+++ b/install.sh
@@ -174,11 +174,11 @@ else
 
   HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
 
-  if [ -z "$HOMEBREW_PREFIX" ]; then
-      echo "HOMEBREW_PREFIX is not set. Installing to $HOMEBREW_PREFIX"
+  if [[ -z "$HOMEBREW_PREFIX" ]]; then
+      echo "HOMEBREW_PREFIX is not set. Installing to ${HOMEBREW_PREFIX}"
   else
-      echo "HOMEBREW_PREFIX is set to: $HOMEBREW_PREFIX"
-      echo "Installing to $HOMEBREW_PREFIX"
+      echo "HOMEBREW_PREFIX is set to: ${HOMEBREW_PREFIX}"
+      echo "Installing to ${HOMEBREW_PREFIX}"
   fi
   
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"


### PR DESCRIPTION
This still defaults to HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew" when HOMEBREW_PREFIX is not set